### PR TITLE
Fix french translation for "Anniversary"

### DIFF
--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -48,7 +48,7 @@ OC.L10N.register(
     "Other" : "Autre",
     "Groups" : "Groupes",
     "Birthday" : "Anniversaire",
-    "Anniversary" : "Anniversaire",
+    "Anniversary" : "Autre date",
     "Date of death" : "Date de décès",
     "Email" : "Adresse e-mail",
     "Instant messaging" : "Messagerie instantanée",

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -46,7 +46,7 @@
     "Other" : "Autre",
     "Groups" : "Groupes",
     "Birthday" : "Anniversaire",
-    "Anniversary" : "Anniversaire",
+    "Anniversary" : "Autre date",
     "Date of death" : "Date de décès",
     "Email" : "Adresse e-mail",
     "Instant messaging" : "Messagerie instantanée",


### PR DESCRIPTION
Anniversary translation from "Anniversaire" to "Autre date" in french.
More info in issue #82